### PR TITLE
Add transaction endpoints 'search' query parameter

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1846,7 +1846,7 @@
           {
             "name": "search",
             "in": "query",
-            "description": "Only return transactions matching a search string. Functions the same as a keyword search in the Pocketsmith web app",
+            "description": "Return transactions matching a keyword search string. The provided string is matched against the transaction amount, account name, payee, category title, note, labels, and the date in yyyy-mm-dd format.",
             "required": false,
             "schema": {
               "type": "string",
@@ -1955,7 +1955,7 @@
           {
             "name": "search",
             "in": "query",
-            "description": "Only return transactions matching a search string. Functions the same as a keyword search in the Pocketsmith web app",
+            "description": "Return transactions matching a keyword search string. The provided string is matched against the transaction amount, account name, payee, category title, note, labels, and the date in yyyy-mm-dd format.",
             "required": false,
             "schema": {
               "type": "string",
@@ -2064,7 +2064,7 @@
           {
             "name": "search",
             "in": "query",
-            "description": "Only return transactions matching a search string. Functions the same as a keyword search in the Pocketsmith web app",
+            "description": "Return transactions matching a keyword search string. The provided string is matched against the transaction amount, account name, payee, category title, note, labels, and the date in yyyy-mm-dd format.",
             "required": false,
             "schema": {
               "type": "string",

--- a/openapi.json
+++ b/openapi.json
@@ -1844,6 +1844,16 @@
             "example": "debit"
           },
           {
+            "name": "search",
+            "in": "query",
+            "description": "Only return transactions matching a search string. Functions the same as a keyword search in the Pocketsmith web app",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+            "example": "Paypal"
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Choose a particular page of the results.",
@@ -1943,6 +1953,16 @@
             "example": "debit"
           },
           {
+            "name": "search",
+            "in": "query",
+            "description": "Only return transactions matching a search string. Functions the same as a keyword search in the Pocketsmith web app",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+            "example": "Paypal"
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Choose a particular page of the results.",
@@ -2040,6 +2060,16 @@
               ]
             },
             "example": "debit"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Only return transactions matching a search string. Functions the same as a keyword search in the Pocketsmith web app",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+            "example": "Paypal"
           },
           {
             "name": "page",


### PR DESCRIPTION
I was reading up on the Pocketsmith API and noticed the open issue. Hope this PR is useful, it attempts to add OpenAPI documentation for the undocumented 'search' parameter mentioned here: https://developers.pocketsmith.com/discuss/5d6ab2f12bceeb006c284982

I just added an entry for the query parameter 'search' to each of the /users/id/transactions, /accounts/id/transactions and
transaction_accounts/id/transactions endpoints

# Checklist

- [x] The OpenAPI JSON file was produced and formatted using Swagger Editor
- [x] The OpenAPI JSON file validates with no errors or warnings in Swagger Editor
- [x] This is a public repo. Your branch name, commits and pull request are appropriate and don't reference internal tooling
