### PR TITLE
fix: correct typo in refund_amount

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -750,7 +750,7 @@
             "description": "The sum of all forecast sources (budget events) in the period, for comparison against the actual amount.",
             "example": -60
           },
-          "refund_amound": {
+          "refund_amount": {
             "type": "number",
             "description": "This attribute tracks the amount that has been refunded or deducted to the actual amount. When a category is set to \"always expense\", any credit transactions are treated as refunds and when set to \"always income\", any debit transactions are treated as deductions.",
             "example": 5.6


### PR DESCRIPTION
Just a small typo fix, originally resolved by @brett-comber in theY4Kman/pocketsmith-api-spec#2

# Checklist

- [ ] The OpenAPI JSON file was produced and formatted using Swagger Editor
- [ ] The OpenAPI JSON file validates with no errors or warnings in Swagger Editor
- [X] This is a public repo. Your branch name, commits and pull request are appropriate and don't reference internal tooling
