### PR TITLE
Updating documentation to reflect changes to the split transactions API

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2284,7 +2284,7 @@
                         "amount": {
                           "type": "number",
                           "description": "The amount for this split transaction.",
-                          "example": 30.00
+                          "example": -30.00
                         },
                         "payee": {
                           "type": "string",
@@ -2310,13 +2310,13 @@
                     },
                     "example": [
                       {
-                        "amount": 30.00,
+                        "amount": -30.00,
                         "category_id": 101,
                         "payee": "Restaurant ABC",
                         "note": "Lunch portion"
                       },
                       {
-                        "amount": 19.95,
+                        "amount": -19.95,
                         "category_id": 102,
                         "payee": "Transport",
                         "note": "Bus fare"

--- a/openapi.json
+++ b/openapi.json
@@ -2242,7 +2242,7 @@
                   },
                   "amount": {
                     "type": "number",
-                    "description": "A new amount for the transaction (signed). A negative amount means the transaction is a debit / expense; a positive amount means it's a credit / income.",
+                    "description": "The amount of the transaction (signed). A positive amount is a credit, and a negative amount is a debit.",
                     "example": -225
                   },
                   "date": {
@@ -2276,7 +2276,7 @@
                   },
                   "splits": {
                     "type": "array",
-                    "description": "Split this transaction into multiple transactions. The correctly calculated remainder amount parameter must be provided, which equals to the amount - sum(split_amounts). Splitting is atomic: all splits are validated before the original transaction and any splits are saved.",
+                    "description": "Split this transaction into multiple transactions. The correctly calculated remainder amount parameter must be provided, which is equal to the amount - sum(split_amounts). Splitting is atomic: all splits are validated before the original transaction and any splits are saved.",
                     "items": {
                       "type": "object",
                       "required": ["amount"],
@@ -2952,7 +2952,7 @@
                   },
                   "amount": {
                     "type": "number",
-                    "description": "The amount of the transaction. A positive amount is a credit, and a negative amount is a debit.",
+                    "description": "The amount of the transaction (signed). A positive amount is a credit, and a negative amount is a debit.",
                     "example": -11.5
                   },
                   "date": {

--- a/openapi.json
+++ b/openapi.json
@@ -2242,7 +2242,7 @@
                   },
                   "amount": {
                     "type": "number",
-                    "description": "A new amount for the transaction. A minus sign at the start of the amount means the transaction is a debit / expense; omitting a sign means it's a credit / income.",
+                    "description": "A new amount for the transaction (signed). A negative amount means the transaction is a debit / expense; a positive amount means it's a credit / income.",
                     "example": -225
                   },
                   "date": {
@@ -2953,7 +2953,7 @@
                   "amount": {
                     "type": "number",
                     "description": "The amount of the transaction. A positive amount is a credit, and a negative amount is a debit.",
-                    "example": 11.5
+                    "example": -11.5
                   },
                   "date": {
                     "type": "string",

--- a/openapi.json
+++ b/openapi.json
@@ -2242,8 +2242,8 @@
                   },
                   "amount": {
                     "type": "number",
-                    "description": "A new amount for the transaction.",
-                    "example": 225
+                    "description": "A new amount for the transaction. A minus sign at the start of the amount means the transaction is a debit / expense; omitting a sign means it's a credit / income.",
+                    "example": -225
                   },
                   "date": {
                     "type": "string",
@@ -2276,7 +2276,7 @@
                   },
                   "splits": {
                     "type": "array",
-                    "description": "Split this transaction into multiple transactions. When provided without an explicit amount parameter, the original transaction's amount will be automatically adjusted to original_amount - sum(split_amounts). When provided with an explicit amount parameter, the amount + sum(split_amounts) must equal the original transaction amount. Splitting is atomic: all splits are validated before the original transaction and any splits are saved.",
+                    "description": "Split this transaction into multiple transactions. The correctly calculated remainder amount parameter must be provided, which equals to the amount - sum(split_amounts). Splitting is atomic: all splits are validated before the original transaction and any splits are saved.",
                     "items": {
                       "type": "object",
                       "required": ["amount"],
@@ -2296,10 +2296,10 @@
                           "description": "The category ID for this split transaction. If not provided, inherits from the parent transaction.",
                           "example": 42
                         },
-                        "note": {
-                          "type": "string",
-                          "description": "A note for this split transaction. If not provided, inherits from the parent transaction.",
-                          "example": "Lunch portion"
+                        "is_transfer": {
+                          "type": "boolean",
+                          "description": "Whether this split transaction should be indicated as a transfer.",
+                          "example": false
                         },
                         "date": {
                           "type": "string",


### PR DESCRIPTION
We no longer accept a separate `note` within a split transaction, in order to more closely match behaviour in the current iteration of the web app.

Likewise, an `is_transfer` parameter is now accepted for transaction splits, to indicate that the split should be treated as a transfer.

Additional information and an updated examples for the transaction amount parameter is also included, clarifying that transaction type is indicated via the sign provided on the transaction amount.

# Checklist

- [x] The OpenAPI JSON file was produced and formatted using Swagger Editor
- [x] The OpenAPI JSON file validates with no errors or warnings in Swagger Editor
